### PR TITLE
docs: add Boldwark Firmware X-Ray to the tools page

### DIFF
--- a/docs/tools/firmware-and-binary-analysis.md
+++ b/docs/tools/firmware-and-binary-analysis.md
@@ -32,10 +32,11 @@ These tools allow engineers to reverse-engineer compiled firmware images, inspec
 | [strings](https://man7.org/linux/man-pages/man1/strings.1.html) | 🐙 | A basic utility that prints the printable character sequences in a file. A simple but effective first step for finding hardcoded secrets. |
 | [FACT (Firmware Analysis & Comparison Tool)](https://fkie-cad.github.io/fact_documentation/) | 🐙 | An extensible platform for performing automated firmware security analysis and comparing firmware versions. |
 | [Firmwalker](https://github.com/craigz28/firmwalker) | 🐙 | A script for searching extracted firmware filesystems for common vulnerabilities and interesting artifacts. |
+| [Boldwark Firmware X-Ray](https://xray.boldwark.com/) | 🥦 | A firmware analyzer that can identify common vulnerabilities and weaknesses from compiled code. |
 | [Finite State](https://finitestate.io/) | 💰 | A commercial product security platform that performs deep binary analysis on firmware to uncover vulnerabilities and generate SBOMs from compiled code. |
 | [IDA Pro](https://hex-rays.com/ida-pro/) | 💰 | A powerful, industry-standard commercial disassembler and debugger for software reverse engineering. |
 | [JEB Decompiler](https://www.pnfsoftware.com/) | 💰 | A professional reverse engineering platform for Android, ARM, and MIPS binaries. |
 
 <!-- vale off -->
-*Type: 💰=Commercial, 🐙=Open-Source*
+*Type: 💰=Commercial, 🥦=Free, 🐙=Open-Source*
 <!-- vale on -->


### PR DESCRIPTION
Hi,

I am not sure if this is the right approach. But I came across this wonderful handbook relating to the CRA and wanted to add Boldwark Firmware X-Ray to the list of tools for firmware analysis.

The tool itself is free although it is commercial, so I added a new emoji symbol.

Thank you